### PR TITLE
Fix missing blueprint registration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,8 +1,14 @@
 from flask import Flask, jsonify
+
+from backend.routes.inventory import inventory_bp
+from backend.routes.predict import predict_bp
 from flask_cors import CORS
 
 app = Flask(__name__)
 CORS(app)
+
+app.register_blueprint(inventory_bp, url_prefix='/api')
+app.register_blueprint(predict_bp, url_prefix='/api')
 
 @app.route('/')
 def index():

--- a/backend/routes/inventory.py
+++ b/backend/routes/inventory.py
@@ -1,7 +1,13 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify, request
+
+inventory_items = []
 
 inventory_bp = Blueprint('inventory', __name__)
 
-@inventory_bp.route('/inventory')
+@inventory_bp.route('/inventory', methods=['GET', 'POST'])
 def inventory_home():
-    return {'message': 'Inventory route'}
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        inventory_items.append(data)
+        return jsonify({'status': 'success'}), 201
+    return jsonify(inventory_items)


### PR DESCRIPTION
## Summary
- register backend blueprints for inventory and predict routes
- implement simple in-memory inventory POST/GET route

## Testing
- `npm run lint` *(fails: React is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_685533dd5040832a9c990301e3871538