### PR TITLE
Implement basic Flask backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+flask-cors

--- a/backend/routes/inventory.py
+++ b/backend/routes/inventory.py
@@ -1,13 +1,10 @@
-from flask import Blueprint, jsonify, request
-
-inventory_items = []
+from flask import Blueprint, jsonify
 
 inventory_bp = Blueprint('inventory', __name__)
 
-@inventory_bp.route('/inventory', methods=['GET', 'POST'])
+
+@inventory_bp.route('/inventory', methods=['GET'])
 def inventory_home():
-    if request.method == 'POST':
-        data = request.get_json() or {}
-        inventory_items.append(data)
-        return jsonify({'status': 'success'}), 201
-    return jsonify(inventory_items)
+    """Return a test JSON response for the inventory endpoint."""
+
+    return jsonify({"items": ["item1", "item2"]})

--- a/backend/routes/predict.py
+++ b/backend/routes/predict.py
@@ -1,7 +1,12 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify, request
 
 predict_bp = Blueprint('predict', __name__)
 
-@predict_bp.route('/predict')
+
+@predict_bp.route('/predict', methods=['POST'])
 def predict_home():
-    return {'message': 'Predict route'}
+    """Return a dummy response for the posted text."""
+
+    data = request.get_json() or {}
+    text = data.get("text", "")
+    return jsonify({"prediction": f"Processed: {text}"})


### PR DESCRIPTION
## Summary
- add backend requirements file with flask deps
- simplify inventory route and add test JSON response
- add POST /predict endpoint returning dummy result

## Testing
- `python3 -m pip install -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68554f2a4dbc832a82a30a98f9131435