### PR TITLE
Initialize DB with SQLAlchemy

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,10 +2,13 @@ from flask import Flask, jsonify
 
 from backend.routes.inventory import inventory_bp
 from backend.routes.predict import predict_bp
+from backend.database.init import init_db
 from flask_cors import CORS
 
 app = Flask(__name__)
 CORS(app)
+
+init_db()
 
 app.register_blueprint(inventory_bp, url_prefix='/api')
 app.register_blueprint(predict_bp, url_prefix='/api')

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,3 +1,9 @@
 class Config:
     DEBUG = True
-    # Add more configuration options as needed
+    # Database connection string, defaulting to a local PostgreSQL database
+    import os
+
+    DATABASE_URL = os.getenv(
+        "DATABASE_URL",
+        "postgresql://postgres:postgres@localhost/postgres",
+    )

--- a/backend/database/init.py
+++ b/backend/database/init.py
@@ -1,5 +1,12 @@
-# Placeholder for database initialization logic
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+from backend.config import Config
+
+engine = create_engine(Config.DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
 
 def init_db():
-    # This function would initialize the database connection
-    pass
+    """Create database tables based on defined models."""
+    Base.metadata.create_all(bind=engine)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,7 @@
+"""Model package initialization with SQLAlchemy Base."""
+
+from backend.database.init import Base
+
+from .user import User
+
+__all__ = ["User", "Base"]

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,4 +1,9 @@
-class User:
-    def __init__(self, user_id, username):
-        self.id = user_id
-        self.username = username
+from sqlalchemy import Column, Integer, String
+
+from backend.database.init import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    username = Column(String, unique=True, nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,4 @@
 Flask
 flask-cors
+SQLAlchemy
+psycopg2-binary


### PR DESCRIPTION
## Summary
- set up SQLAlchemy in backend
- define `User` model using SQLAlchemy
- create tables on app startup
- add PostgreSQL connection string config

## Testing
- `python -m py_compile backend/app.py backend/config.py backend/database/init.py backend/models/user.py backend/models/__init__.py`
- `python -m pip install -r backend/requirements.txt`
- `DATABASE_URL=sqlite:///test.db python - <<'PY'
from backend.database.init import init_db, engine
init_db()
print('engine url:', engine.url)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6855836991a0832a9284f52a76f80ef9