### PR TITLE
Implement basic user API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify
 
 from backend.routes.inventory import inventory_bp
 from backend.routes.predict import predict_bp
+from backend.routes.users import users_bp
 from backend.database.init import init_db
 from flask_cors import CORS
 
@@ -12,6 +13,7 @@ init_db()
 
 app.register_blueprint(inventory_bp, url_prefix='/api')
 app.register_blueprint(predict_bp, url_prefix='/api')
+app.register_blueprint(users_bp, url_prefix='/api')
 
 @app.route('/')
 def index():

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -2,9 +2,13 @@ from sqlalchemy import Column, Integer, String
 
 from backend.database.init import Base
 
+
 class User(Base):
+    """SQLAlchemy model for application users."""
+
     __tablename__ = "users"
     __table_args__ = {"extend_existing": True}
 
     id = Column(Integer, primary_key=True)
-    username = Column(String, unique=True, nullable=False)
+    name = Column(String, nullable=False)
+    email = Column(String, unique=True, nullable=False)

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -1,0 +1,47 @@
+from flask import Blueprint, jsonify, request
+from backend.database.init import SessionLocal
+from backend.models.user import User
+
+users_bp = Blueprint('users', __name__)
+
+
+@users_bp.route('/users', methods=['GET'])
+def list_users():
+    """Return all users as JSON."""
+    session = SessionLocal()
+    try:
+        users = session.query(User).all()
+        data = [
+            {
+                "id": user.id,
+                "name": user.name,
+                "email": user.email,
+            }
+            for user in users
+        ]
+        return jsonify(data)
+    finally:
+        session.close()
+
+
+@users_bp.route('/users', methods=['POST'])
+def create_user():
+    """Create a new user with name and email."""
+    data = request.get_json() or {}
+    name = data.get('name')
+    email = data.get('email')
+    if not name or not email:
+        return jsonify({'error': 'name and email required'}), 400
+
+    session = SessionLocal()
+    try:
+        user = User(name=name, email=email)
+        session.add(user)
+        session.commit()
+        return jsonify({
+            'id': user.id,
+            'name': user.name,
+            'email': user.email,
+        }), 201
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- model users with name and email
- add REST endpoints to list and create users
- register users blueprint in app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68566636d260832aaa6335a2b8697b08