### PR TITLE
Add profile fields to User model and endpoints

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, Date
+
+from datetime import date
 
 from database.init import Base
 
@@ -12,3 +14,8 @@ class User(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     email = Column(String, unique=True, nullable=False)
+    height = Column(Integer)
+    weight = Column(Integer)
+    birthdate = Column(Date)
+    gender = Column(String)
+    goal = Column(String)

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify, request
 from backend.database.init import SessionLocal
 from backend.models.user import User
+from datetime import datetime
 
 users_bp = Blueprint('users', __name__)
 
@@ -16,6 +17,11 @@ def list_users():
                 "id": user.id,
                 "name": user.name,
                 "email": user.email,
+                "height": user.height,
+                "weight": user.weight,
+                "birthdate": user.birthdate.isoformat() if user.birthdate else None,
+                "gender": user.gender,
+                "goal": user.goal,
             }
             for user in users
         ]
@@ -26,22 +32,48 @@ def list_users():
 
 @users_bp.route('/users', methods=['POST'])
 def create_user():
-    """Create a new user with name and email."""
+    """Create a new user with the provided fields."""
     data = request.get_json() or {}
     name = data.get('name')
     email = data.get('email')
     if not name or not email:
         return jsonify({'error': 'name and email required'}), 400
 
+    height = data.get('height')
+    weight = data.get('weight')
+    birthdate_str = data.get('birthdate')
+    gender = data.get('gender')
+    goal = data.get('goal')
+
+    birthdate = None
+    if birthdate_str:
+        try:
+            birthdate = datetime.fromisoformat(birthdate_str).date()
+        except ValueError:
+            return jsonify({'error': 'Invalid birthdate format. Use ISO format (YYYY-MM-DD)'}), 400
+
     session = SessionLocal()
     try:
-        user = User(name=name, email=email)
+        user = User(
+            name=name,
+            email=email,
+            height=height,
+            weight=weight,
+            birthdate=birthdate,
+            gender=gender,
+            goal=goal,
+        )
         session.add(user)
         session.commit()
         return jsonify({
             'id': user.id,
             'name': user.name,
             'email': user.email,
+            'height': user.height,
+            'weight': user.weight,
+            'birthdate': user.birthdate.isoformat() if user.birthdate else None,
+            'gender': user.gender,
+            'goal': user.goal,
         }), 201
     finally:
         session.close()


### PR DESCRIPTION
## Summary
- extend `User` model with height, weight, birthdate, gender and goal
- expose new fields on `/users` routes
- parse and validate `birthdate` when creating a user

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -q -r backend/requirements.txt`
- `python backend/app.py` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68569ae3242c832a940971810287fe17