### PR TITLE
Add activity log model and dashboard widget

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,7 @@ from backend.routes.inventory import inventory_bp
 from backend.routes.predict import predict_bp
 from backend.routes.users import users_bp
 from backend.routes.recommend import recommend_bp
+from backend.routes.activity_log import activity_log_bp
 from backend.database.init import init_db
 from flask_cors import CORS
 
@@ -16,6 +17,7 @@ app.register_blueprint(inventory_bp, url_prefix='/api')
 app.register_blueprint(predict_bp, url_prefix='/api')
 app.register_blueprint(users_bp, url_prefix='/api')
 app.register_blueprint(recommend_bp, url_prefix='/api')
+app.register_blueprint(activity_log_bp, url_prefix='/api')
 
 @app.route('/')
 def index():

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -4,5 +4,6 @@ from backend.database.init import Base
 
 from .user import User
 from .inventory import Inventory
+from .activity_log import ActivityLog
 
-__all__ = ["User", "Inventory", "Base"]
+__all__ = ["User", "Inventory", "ActivityLog", "Base"]

--- a/backend/models/activity_log.py
+++ b/backend/models/activity_log.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, Integer, String, Date, ForeignKey
+from sqlalchemy.orm import relationship
+
+from backend.database.init import Base
+
+
+class ActivityLog(Base):
+    """User activity log."""
+
+    __tablename__ = "activity_log"
+    __table_args__ = {"extend_existing": True}
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    activity_type = Column(String, nullable=False)
+    duration_minutes = Column(Integer, nullable=False)
+    calories_burned = Column(Integer, nullable=False)
+    date = Column(Date, nullable=False)
+
+    user = relationship("User", backref="activity_logs")

--- a/backend/routes/activity_log.py
+++ b/backend/routes/activity_log.py
@@ -1,0 +1,97 @@
+from flask import Blueprint, jsonify, request
+from datetime import datetime
+
+from backend.database.init import SessionLocal
+from backend.models.activity_log import ActivityLog
+
+activity_log_bp = Blueprint('activity_log', __name__)
+
+
+@activity_log_bp.route('/activity-log', methods=['GET'])
+def list_logs():
+    """Return all activity logs."""
+    session = SessionLocal()
+    try:
+        logs = session.query(ActivityLog).all()
+        data = [
+            {
+                'id': log.id,
+                'user_id': log.user_id,
+                'activity_type': log.activity_type,
+                'duration_minutes': log.duration_minutes,
+                'calories_burned': log.calories_burned,
+                'date': log.date.isoformat(),
+            }
+            for log in logs
+        ]
+        return jsonify(data)
+    finally:
+        session.close()
+
+
+@activity_log_bp.route('/activity-log', methods=['POST'])
+def create_log():
+    """Create a new activity log."""
+    data = request.get_json() or {}
+    user_id = data.get('user_id')
+    activity_type = data.get('activity_type')
+    duration_minutes = data.get('duration_minutes')
+    calories_burned = data.get('calories_burned')
+    date_str = data.get('date')
+
+    if (
+        user_id is None
+        or not activity_type
+        or duration_minutes is None
+        or calories_burned is None
+        or not date_str
+    ):
+        return jsonify({'error': 'All fields are required'}), 400
+
+    try:
+        date = datetime.fromisoformat(date_str).date()
+    except ValueError:
+        return jsonify({'error': 'Invalid date format. Use ISO format (YYYY-MM-DD)'}), 400
+
+    session = SessionLocal()
+    try:
+        log = ActivityLog(
+            user_id=user_id,
+            activity_type=activity_type,
+            duration_minutes=duration_minutes,
+            calories_burned=calories_burned,
+            date=date,
+        )
+        session.add(log)
+        session.commit()
+        return (
+            jsonify(
+                {
+                    'id': log.id,
+                    'user_id': log.user_id,
+                    'activity_type': log.activity_type,
+                    'duration_minutes': log.duration_minutes,
+                    'calories_burned': log.calories_burned,
+                    'date': log.date.isoformat(),
+                }
+            ),
+            201,
+        )
+    finally:
+        session.close()
+
+
+@activity_log_bp.route('/activity-log/<int:log_id>', methods=['DELETE'])
+def delete_log(log_id: int):
+    """Delete an activity log by id."""
+    session = SessionLocal()
+    try:
+        log = session.query(ActivityLog).get(log_id)
+        if not log:
+            return jsonify({'error': 'Log not found'}), 404
+
+        session.delete(log)
+        session.commit()
+        return jsonify({'message': 'Log deleted'})
+    finally:
+        session.close()

--- a/src/views/dashboard/ActivityLog.jsx
+++ b/src/views/dashboard/ActivityLog.jsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react'
+import {
+  CCard,
+  CCardBody,
+  CCardHeader,
+  CForm,
+  CFormInput,
+  CButton,
+  CListGroup,
+  CListGroupItem,
+} from '@coreui/react'
+import axios from 'axios'
+
+/**
+ * ActivityLog
+ * Kullanıcının yaptığı aktiviteleri listeleyen ve ekleme yapmaya yarayan basit bileşen.
+ */
+const ActivityLog = () => {
+  const [logs, setLogs] = useState([])
+  const [userId, setUserId] = useState('')
+  const [activityType, setActivityType] = useState('')
+  const [duration, setDuration] = useState('')
+  const [calories, setCalories] = useState('')
+  const [date, setDate] = useState('')
+
+  const fetchLogs = async () => {
+    try {
+      const res = await axios.get('/api/activity-log')
+      setLogs(res.data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    fetchLogs()
+  }, [])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await axios.post('/api/activity-log', {
+        user_id: userId,
+        activity_type: activityType,
+        duration_minutes: duration,
+        calories_burned: calories,
+        date,
+      })
+      setLogs([...logs, res.data])
+      setUserId('')
+      setActivityType('')
+      setDuration('')
+      setCalories('')
+      setDate('')
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const handleDelete = async (id) => {
+    try {
+      await axios.delete(`/api/activity-log/${id}`)
+      setLogs(logs.filter((log) => log.id !== id))
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <CCard className="mb-4">
+      <CCardHeader>Aktivite Günlüğü</CCardHeader>
+      <CCardBody>
+        <CForm className="row g-3" onSubmit={handleSubmit}>
+          <CFormInput
+            label="User ID"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+          />
+          <CFormInput
+            label="Aktivite Türü"
+            value={activityType}
+            onChange={(e) => setActivityType(e.target.value)}
+          />
+          <CFormInput
+            label="Süre (dakika)"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+          />
+          <CFormInput
+            label="Yakılan Kalori"
+            value={calories}
+            onChange={(e) => setCalories(e.target.value)}
+          />
+          <CFormInput
+            type="date"
+            label="Tarih"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+          <CButton type="submit">Ekle</CButton>
+        </CForm>
+        <CListGroup className="mt-4">
+          {logs.map((log) => (
+            <CListGroupItem
+              key={log.id}
+              className="d-flex justify-content-between align-items-center"
+            >
+              <span>
+                {log.date} - {log.activity_type} ({log.duration_minutes} dk,
+                {` ${log.calories_burned} kcal`})
+              </span>
+              <CButton
+                color="danger"
+                size="sm"
+                onClick={() => handleDelete(log.id)}
+              >
+                Sil
+              </CButton>
+            </CListGroupItem>
+          ))}
+        </CListGroup>
+      </CCardBody>
+    </CCard>
+  )
+}
+
+export default ActivityLog

--- a/src/views/dashboard/Dashboard.jsx
+++ b/src/views/dashboard/Dashboard.jsx
@@ -12,6 +12,7 @@ import {
 } from '@coreui/react'
 import { CChartBar } from '@coreui/react-chartjs'
 import axios from 'axios'
+import ActivityLog from './ActivityLog'
 
 /**
  * Dashboard
@@ -124,6 +125,11 @@ const Dashboard = () => {
             )}
           </CCardBody>
         </CCard>
+      </CCol>
+
+      {/* Aktivite günlüğü */}
+      <CCol xs={12} lg={6}>
+        <ActivityLog />
       </CCol>
     </CRow>
   )


### PR DESCRIPTION
## Summary
- define `ActivityLog` SQLAlchemy model
- expose CRUD endpoints under `/api/activity-log`
- register the new blueprint
- display activity log list on the Dashboard page

## Testing
- `python -m py_compile backend/app.py backend/models/activity_log.py backend/routes/activity_log.py backend/models/__init__.py`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856c85075e4832aab8cc57dde783acd