### PR TITLE
Fix import paths in backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,6 @@
 from flask import Flask, jsonify
+from flask_cors import CORS
+
 from backend.routes.inventory import inventory_bp
 from backend.routes.predict import predict_bp
 from backend.routes.users import users_bp
@@ -6,13 +8,6 @@ from backend.routes.recommend import recommend_bp
 from backend.routes.recommendation import recommendation_bp
 from backend.routes.activity_log import activity_log_bp
 from backend.database.init import init_db
-from routes.inventory import inventory_bp
-from routes.predict import predict_bp
-from flask_cors import CORS
-from database.init import init_db
-from models import user
-
-init_db()
 
 
 app = Flask(__name__)

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,10 +1,9 @@
-DATABASE_URL = "postgresql://postgres:12345678@localhost:5432/diyetdb"
+import os
 
 class Config:
-    DEBUG = True
-    # Database connection string, defaulting to a local PostgreSQL database
-    import os
+    """Application configuration."""
 
+    DEBUG = True
     DATABASE_URL = os.getenv(
         "DATABASE_URL",
         "postgresql://postgres:postgres@localhost/postgres",

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,0 +1,18 @@
+
+"""Blueprint package exports."""
+
+from .inventory import inventory_bp
+from .predict import predict_bp
+from .users import users_bp
+from .recommend import recommend_bp
+from .recommendation import recommendation_bp
+from .activity_log import activity_log_bp
+
+__all__ = [
+    "inventory_bp",
+    "predict_bp",
+    "users_bp",
+    "recommend_bp",
+    "recommendation_bp",
+    "activity_log_bp",
+]

--- a/backend/routes/inventory.py
+++ b/backend/routes/inventory.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, jsonify, request
 
-from database.init import SessionLocal
-from models.inventory import Inventory
+from backend.database.init import SessionLocal
+from backend.models.inventory import Inventory
 
 inventory_bp = Blueprint('inventory', __name__)
 


### PR DESCRIPTION
## Summary
- correct inventory route imports
- define blueprints in `backend.routes` for simpler imports
- simplify database config
- clean up app module imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python tools/load_recipes.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685888e4133c832ab64368e3b199def0