### PR TITLE
Fix absolute imports in utilities

### DIFF
--- a/tools/load_recipes.py
+++ b/tools/load_recipes.py
@@ -1,14 +1,5 @@
 import os
-import sys
-from pathlib import Path
 import pandas as pd
-
-# Ensure the project root is on the import path when executed directly
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
-# Allow models that expect 'database' package to be imported
-import backend.database as _database
-sys.modules.setdefault("database", _database)
 
 from backend.database.init import SessionLocal, init_db
 from backend.models.recipe import Recipe


### PR DESCRIPTION
## Summary
- clean up `tools/load_recipes.py`
- remove path hacking and rely on direct imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685890fe2990832ab044732526182325