### PR TITLE
Implement settings-driven calorie and BMI features

### DIFF
--- a/src/components/AppContent.js
+++ b/src/components/AppContent.js
@@ -23,7 +23,12 @@ const AppContent = () => {
               )
             )
           })}
-          <Route path="/" element={<Navigate to="dashboard" replace />} />
+          <Route
+            path="/"
+            element={
+              <Navigate to={localStorage.getItem('profile') ? 'dashboard' : 'settings'} replace />
+            }
+          />
         </Routes>
       </Suspense>
     </CContainer>

--- a/src/views/calorie-tracker/CalorieTracker.js
+++ b/src/views/calorie-tracker/CalorieTracker.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { CCard, CCardBody, CCardHeader, CForm, CFormInput, CButton, CAlert } from '@coreui/react'
 
 /**
@@ -6,18 +6,28 @@ import { CCard, CCardBody, CCardHeader, CForm, CFormInput, CButton, CAlert } fro
  * Kullanıcının yaş, kilo, boy ve aktivite seviyesine göre günlük kalori ihtiyacını hesaplar.
  */
 const CalorieTracker = () => {
-  const [age, setAge] = useState('')
-  const [weight, setWeight] = useState('')
-  const [height, setHeight] = useState('')
+  const [profile, setProfile] = useState(null)
   const [activity, setActivity] = useState(1.2)
   const [calorie, setCalorie] = useState(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('profile')
+    if (!stored) return
+    try {
+      const p = JSON.parse(stored)
+      setProfile(p)
+    } catch (_) {
+      // ignore
+    }
+  }, [])
 
   // Basit BMR ve kalori hesaplama
   const handleCalculate = (e) => {
     e.preventDefault()
-    const h = parseFloat(height)
-    const w = parseFloat(weight)
-    const a = parseFloat(age)
+    if (!profile) return
+    const h = parseFloat(profile.height)
+    const w = parseFloat(profile.weight)
+    const a = parseFloat(profile.age)
     if (!h || !w || !a) return
     // Harris-Benedict
     const bmr = 88.36 + 13.4 * w + 4.8 * h - 5.7 * a
@@ -28,21 +38,29 @@ const CalorieTracker = () => {
     <CCard>
       <CCardHeader>Günlük Kalori İhtiyacı</CCardHeader>
       <CCardBody>
-        <CForm className="row g-3" onSubmit={handleCalculate}>
-          <CFormInput label="Yaş" value={age} onChange={(e) => setAge(e.target.value)} />
-          <CFormInput
-            label="Kilo (kg)"
-            value={weight}
-            onChange={(e) => setWeight(e.target.value)}
-          />
-          <CFormInput label="Boy (cm)" value={height} onChange={(e) => setHeight(e.target.value)} />
-          <CFormInput
-            label="Aktivite Katsayısı"
-            value={activity}
-            onChange={(e) => setActivity(e.target.value)}
-          />
-          <CButton type="submit">Hesapla</CButton>
-        </CForm>
+        {profile ? (
+          <>
+            <p className="mb-3">
+              Yaş: {profile.age}, Kilo: {profile.weight} kg, Boy: {profile.height} cm
+            </p>
+            <CForm className="row g-3" onSubmit={handleCalculate}>
+              <CFormInput
+                label="Aktivite Katsayısı"
+                value={activity}
+                onChange={(e) => setActivity(e.target.value)}
+              />
+              <CButton type="submit">Hesapla</CButton>
+            </CForm>
+            <ul className="mt-3">
+              <li>Hareketsiz: 1.2</li>
+              <li>Hafif Aktif (1-3 gün egzersiz): 1.375</li>
+              <li>Orta Aktif (3-5 gün egzersiz): 1.55</li>
+              <li>Çok Aktif (6-7 gün egzersiz): 1.725</li>
+            </ul>
+          </>
+        ) : (
+          <CAlert color="warning">Profil bilgilerinizi önce Ayarlar kısmından giriniz.</CAlert>
+        )}
         {calorie && (
           <CAlert color="success" className="mt-3">
             Tahmini günlük ihtiyaç: {calorie} kalori

--- a/src/views/settings/Settings.js
+++ b/src/views/settings/Settings.js
@@ -9,6 +9,7 @@ const Settings = () => {
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [age, setAge] = useState('')
   const [weight, setWeight] = useState('')
   const [height, setHeight] = useState('')
   const [profile, setProfile] = useState(null)
@@ -24,6 +25,7 @@ const Settings = () => {
         setName(p.name || '')
         setEmail(p.email || '')
         setPassword(p.password || '')
+        setAge(p.age || '')
         setWeight(p.weight || '')
         setHeight(p.height || '')
         setEditing(false)
@@ -35,7 +37,7 @@ const Settings = () => {
 
   const handleSave = (e) => {
     e.preventDefault()
-    const data = { name, email, password, weight, height }
+    const data = { name, email, password, age, weight, height }
     localStorage.setItem('profile', JSON.stringify(data))
     setProfile(data)
     setMessage('Bilgiler kaydedildi')
@@ -58,6 +60,12 @@ const Settings = () => {
             />
             <CFormInput
               type="number"
+              label="Yaş"
+              value={age}
+              onChange={(e) => setAge(e.target.value)}
+            />
+            <CFormInput
+              type="number"
               label="Kilo (kg)"
               value={weight}
               onChange={(e) => setWeight(e.target.value)}
@@ -71,25 +79,40 @@ const Settings = () => {
             <CButton type="submit">Kaydet</CButton>
           </CForm>
         ) : (
-          <>
+          <CRow className="gy-3">
             {profile && (
-              <div className="mb-3">
-                <p>
-                  <strong>Ad:</strong> {profile.name}
-                </p>
-                <p>
-                  <strong>Email:</strong> {profile.email}
-                </p>
-                <p>
-                  <strong>Kilo:</strong> {profile.weight} kg
-                </p>
-                <p>
-                  <strong>Boy:</strong> {profile.height} cm
-                </p>
-              </div>
+              <CCol md={6}>
+                <CCard className="h-100">
+                  <CCardHeader>Bilgilerim</CCardHeader>
+                  <CCardBody>
+                    <p>
+                      <strong>Ad:</strong> {profile.name}
+                    </p>
+                    <p>
+                      <strong>Email:</strong> {profile.email}
+                    </p>
+                    <p>
+                      <strong>Yaş:</strong> {profile.age}
+                    </p>
+                    <p>
+                      <strong>Kilo:</strong> {profile.weight} kg
+                    </p>
+                    <p>
+                      <strong>Boy:</strong> {profile.height} cm
+                    </p>
+                  </CCardBody>
+                </CCard>
+              </CCol>
             )}
-            <CButton onClick={() => setEditing(true)}>Düzenle</CButton>
-          </>
+            <CCol md={6}>
+              <CCard className="h-100 text-center">
+                <CCardHeader>Düzenle</CCardHeader>
+                <CCardBody className="d-flex justify-content-center align-items-center">
+                  <CButton onClick={() => setEditing(true)}>Düzenle</CButton>
+                </CCardBody>
+              </CCard>
+            </CCol>
+          </CRow>
         )}
         {message && (
           <CAlert color="success" className="mt-3">


### PR DESCRIPTION
## Summary
- show settings page first if no profile exists
- let users enter age in settings
- display saved info and edit button in two cards
- load profile info in calorie tracker and list activity factors

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6860e9ef6854832aa5a72a0a20e91dfc