### PR TITLE
Customize template branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta name="description" content="CoreUI for React - Open Source Bootstrap Admin Template">
     <meta name="author" content="Łukasz Holeczek">
     <meta name="keyword" content="Bootstrap,Admin,Template,Open,Source,CSS,SCSS,HTML,RWD,Dashboard,React">
-    <title>CoreUI Free React.js Admin Template</title>
+    <title>Bitirme Projesi</title>
     <link rel="manifest" href="/manifest.json">
   </head>
   <body>

--- a/src/components/AppFooter.js
+++ b/src/components/AppFooter.js
@@ -2,22 +2,7 @@ import React from 'react'
 import { CFooter } from '@coreui/react'
 
 const AppFooter = () => {
-  return (
-    <CFooter className="px-4">
-      <div>
-        <a href="https://coreui.io" target="_blank" rel="noopener noreferrer">
-          CoreUI
-        </a>
-        <span className="ms-1">&copy; 2025 creativeLabs.</span>
-      </div>
-      <div className="ms-auto">
-        <span className="me-1">Powered by</span>
-        <a href="https://coreui.io/react" target="_blank" rel="noopener noreferrer">
-          CoreUI React Admin &amp; Dashboard Template
-        </a>
-      </div>
-    </CFooter>
-  )
+  return <CFooter className="px-4" />
 }
 
 export default React.memo(AppFooter)

--- a/src/components/AppSidebar.js
+++ b/src/components/AppSidebar.js
@@ -36,9 +36,8 @@ const AppSidebar = () => {
       }}
     >
       <CSidebarHeader className="border-bottom">
-        <CSidebarBrand to="/">
-          <CIcon customClassName="sidebar-brand-full" icon={logo} height={32} />
-          <CIcon customClassName="sidebar-brand-narrow" icon={sygnet} height={32} />
+        <CSidebarBrand to="/" className="fw-semibold fs-5">
+          Bitirme Projesi
         </CSidebarBrand>
         <CCloseButton
           className="d-lg-none"

--- a/src/components/header/AppHeaderDropdown.js
+++ b/src/components/header/AppHeaderDropdown.js
@@ -22,13 +22,11 @@ import {
 } from '@coreui/icons'
 import CIcon from '@coreui/icons-react'
 
-import avatar8 from './../../assets/images/avatars/8.jpg'
-
 const AppHeaderDropdown = () => {
   return (
     <CDropdown variant="nav-item">
       <CDropdownToggle placement="bottom-end" className="py-0 pe-0" caret={false}>
-        <CAvatar src={avatar8} size="md" />
+        <CAvatar size="md" style={{ backgroundColor: 'black' }} />
       </CDropdownToggle>
       <CDropdownMenu className="pt-0" placement="bottom-end">
         <CDropdownHeader className="bg-body-secondary fw-semibold mb-2">Account</CDropdownHeader>


### PR DESCRIPTION
## Summary
- simplify footer and remove CoreUI branding
- replace sidebar logo with "Bitirme Projesi" text
- use plain black avatar instead of photo in header dropdown
- update HTML title

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68616c21bb58832a87d7ac475c87f80a